### PR TITLE
Https protocol module checks

### DIFF
--- a/core/main.pl
+++ b/core/main.pl
@@ -8,11 +8,25 @@ my $can_regexp=1;
 eval "use Regexp::Common \"URI\"";
 if($@) { $can_regexp=0; }
 
+my $can_https=1;
+eval "use LWP::Protocol::https";
+if($@) { $can_https=0; }
+
+$ua = LWP::UserAgent->new();
+$ua->protocols_allowed( [ 'http' ] );
+if ($can_https) {
+  $ua->ssl_opts( 'verify_hostname' => 0 );
+  push @{ $ua->protocols_allowed }, 'https';
+} else {
+  if($target =~ /^https:/) {
+    print color("red");
+    print "[+] Target uses HTTPS, but module LWP::Protocol::https is not available!\n\n";
+    print color("reset");
+    exit (1);
+  }
+}
 
 print color("blue");
-
-$ua = LWP::UserAgent->new(ssl_opts => { verify_hostname => 0 });
-$ua->protocols_allowed( [ 'http','https'] );
 
 $timeout = $timeout || 60;
 $ua->timeout($timeout);

--- a/core/main.pl
+++ b/core/main.pl
@@ -8,17 +8,17 @@ my $can_regexp=1;
 eval "use Regexp::Common \"URI\"";
 if($@) { $can_regexp=0; }
 
-my $can_https=1;
-eval "use LWP::Protocol::https";
-if($@) { $can_https=0; }
-
 $ua = LWP::UserAgent->new();
 $ua->protocols_allowed( [ 'http' ] );
-if ($can_https) {
-  $ua->ssl_opts( 'verify_hostname' => 0 );
-  push @{ $ua->protocols_allowed }, 'https';
-} else {
-  if($target =~ /^https:/) {
+if($target =~ /^https:\/\//) {
+  my $can_https=1;
+  eval "use LWP::Protocol::https";
+  if($@) { $can_https=0; }
+
+  if ($can_https) {
+    $ua->ssl_opts( 'verify_hostname' => 0 );
+    push @{ $ua->protocols_allowed }, 'https';
+  } else {
     print color("red");
     print "[+] Target uses HTTPS, but module LWP::Protocol::https is not available!\n\n";
     print color("reset");

--- a/core/update.pl
+++ b/core/update.pl
@@ -1,20 +1,30 @@
 #!/usr/bin/perl
 
+my $can_https=1;
+eval "use LWP::Protocol::https";
+if($@) { $can_https=0; }
+
+if (!$can_https) {
+  print color("red");
+  print "[+] Update requires HTTPS, but module LWP::Protocol::https is not available!\n\n";
+  print color("reset");
+  exit (1);
+}
+
 my $browser = LWP::UserAgent->new;
 $browser->timeout(60);
-$browser = LWP::UserAgent->new(ssl_opts => { verify_hostname => 0 });
 $browser->protocols_allowed( [ 'http','https'] );
 
 
 
 print "\n[+] Checking newest version\n";
 
-my $response = $browser->get('http://raw.githubusercontent.com/rezasp/joomscan/master/version');
+my $response = $browser->get('https://raw.githubusercontent.com/rezasp/joomscan/master/version');
 
 if($response->is_success){
 	if($response->decoded_content !~ /$version/)
 	{
-		print "\n[!] New version available on http://github.com/rezasp/joomscan \n\n";
+		print "\n[!] New version available on https://github.com/rezasp/joomscan\n\n";
 	}else
 	{
 		 print "\n[!] No new version available\n\n";


### PR DESCRIPTION
This PR fixes #15 
If HTTPS protocol for LWP is missing and target uses HTTPS, error message is displayed and tool exits. The same occurs when update check is requested.
GitHub uses HTTPS now, so update check uses HTTPS links now ( to avoid unnecessary redirects ). Verification of hostname has been not disabled ( update source should have matching hostname with HTTPS certificate ).