### PR TITLE
Fix target checks, date format in report and weekday typo

### DIFF
--- a/core/header.pl
+++ b/core/header.pl
@@ -91,7 +91,12 @@ GetOptions(
   'version' => sub { print "\n\nVersion : $version\n\n";exit; },
 
 );
-if($target !~ /\./){exit 0;}
-if($target !~ /http/) { $target = "http://$target"; };
+if($target !~ /\S/){
+  print color("red");
+  print "[+] No target specified!\n\n";
+  print color("reset");
+  exit (1);
+}
+if($target !~ /^https?:\/\//) { $target = "http://$target"; };
 
 #End help Function

--- a/core/main.pl
+++ b/core/main.pl
@@ -17,11 +17,11 @@ $ua->protocols_allowed( [ 'http','https'] );
 $timeout = $timeout || 60;
 $ua->timeout($timeout);
 
-@weekday = ("Sunday", "Monday", "Tuesday", "Wednesday", "thursday", "Friday", "Saturday");
+@weekday = ("Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday");
 ($sec,$min,$hour,$mday,$mon,$year,$wday,$yday,$isdst) = localtime();;
 $year = $year + 1900;
 $mon += 1;
-$stime="$mday/$mon/$year $hour:$min:$sec $weekday[$wday]";
+$stime="$year-$mon-$mday $hour:$min:$sec $weekday[$wday]";
 
 
 @uagnt=('Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.0.5) Gecko/20060719 Firefox/1.5.0.5'


### PR DESCRIPTION
Fix start time so it is more internationally readable ( for US it can get mixed up if day and month are first, new format is more universal )
Fix missing protocol check so it looks from beginning only ( not in the whole string )
Fix target check so it can be also localhost or other non-fqdn entry and exit with error if empty ( until now joomscan exited with return code 0 without any error message shown )