### PR TITLE
fix: Issue 29 - set initial timeout for slow pages

### DIFF
--- a/core/ver.pl
+++ b/core/ver.pl
@@ -1,7 +1,7 @@
 #start Version finder
 dprint("Detecting Joomla Version");
 
-$ua->timeout(10);
+$ua->timeout($timeout);
 
 my $response = $ua->get("$target");
 if (!$response->is_success) {


### PR DESCRIPTION
As per issue rezasp/joomscan#29 some pages are too slow to make initial base connection which checks if target is alive.

This fixes #29 and allow user to scan usually slower websites or long-trace DCs.