### PR TITLE
support LWP::Protocol::https (i.e. HTTPS scans) in the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,9 @@ FROM perl:5-slim
 COPY . /home/joomscan
 WORKDIR /home/joomscan
 RUN adduser joomscan --disabled-password --disabled-login --gecos "" --no-create-home --home /home/joomscan && chown joomscan:joomscan /home/joomscan -R
-RUN apt-get update && apt-get install -y --no-install-recommends libc6-dev=2.24-11+deb9u3 gcc=4:6.3.0-4 && rm /var/lib/apt/lists/* -R && cpanm Bundle::LWP
+RUN apt-get update && apt-get install -y libc6-dev gcc libcrypt-ssleay-perl openssl libssl-dev libz-dev && \
+  rm /var/lib/apt/lists/* -R
+RUN cpanm Bundle::LWP && cpanm LWP::Protocol::https
 USER joomscan
 ENTRYPOINT ["perl", "joomscan.pl"]
 CMD ["-h"]


### PR DESCRIPTION
(this also fixes building the docker image at all - deps were no longer available)