### PR TITLE
Fix components.pl bug

### DIFF
--- a/exploit/components.pl
+++ b/exploit/components.pl
@@ -74,8 +74,8 @@ while( my $row = <$DB>)  {
 								$tmp.="[!] We found the component \"com_$xm\", but since the component version was not available we cannot ensure that it's vulnerable, please test it yourself.\n";
 							}
 							
-							$tmp.= "Title : ". @matches[0] . "\n" if @matches[0] !~ /-/;
-							$tmp.=  "Exploit date : ". @matches[2]. "\n" if @matches[2] !~ /-/;
+							$tmp.= "Title : ". @matches[0] . "\n" if @matches[0] ne "-";
+							$tmp.=  "Exploit date : ". @matches[2]. "\n" if @matches[2] ne "-";
 							$tmp.=  "Reference : http://www.cvedetails.com/cve/CVE-". @matches[3]. "\n" if @matches[3] !~ /^-$/ and @matches[3] !~ /\,/;
 							if(index(@matches[3], ',') != -1){
 								print 123;


### PR DESCRIPTION
When the detected version of the component matches the vulnerable version stored in db, the scanner does not output "[!] We found vulnerable component". Instead, it outputs "the version was not available".